### PR TITLE
Adding Github action for Openshift deployment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,55 @@
+## This is basic continuous integration build for your Quarkus application.
+
+name: OpenShift Quarkus Codestart CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  secrets:
+    name: check secrets
+    runs-on: ubuntu-20.04
+    outputs:
+      available: ${{ steps.secrets.outputs.available }}
+    steps:
+      - name: Check whether OpenShift requests should be done
+        id: secrets
+        env:
+          secretsavailable: ${{ secrets.OPENSHIFT_SERVER_URL != '' && secrets.OPENSHIFT_TOKEN != '' && github.event.pull_request == '' }}
+        run: |
+          echo "available: ${{ env.secretsavailable }}"
+          echo "::set-output name=available::${{ env.secretsavailable }}"
+
+  build:
+    needs: secrets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build
+        run: |
+          ./mvnw -B verify
+      - name: Authenticate and set context
+        if: ${{ needs.secrets.outputs.available }}
+        uses: redhat-actions/oc-login@v1
+        with:
+          openshift_server_url: ${{ secrets.OPENSHIFT_SERVER_URL }}
+          openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
+          namespace: ${{ secrets.OPENSHIFT_NAMESPACE }}
+          insecure_skip_tls_verify: true
+      - name: Deploy
+        if: ${{ needs.secrets.outputs.available }}
+        run: |
+          ./mvnw -B verify -DskipTests -Dquarkus.kubernetes.deploy=true -Dquarkus.kubernetes.expose=true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,9 +4,9 @@ name: OpenShift Quarkus Codestart CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   secrets:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+This project uses Quarkus, the Supersonic Subatomic Java Framework.
+
+You just started working with Quarkus and you want to try out how to deploy your application on Openshift. This project uses the Github actions and deploys this barebones app onto the [Red Hat Developer Sandbox for Openshift](https://developers.rehdat.com/developer-sandbox)
+
+To deploy this project on the Sandbox, make sure you setup 3 secrets in your github repo.
+- OPENSHIFT_SERVER_URL
+- OPENSHIFT_NAMESPACE
+- OPENSHIFT_TOKEN
+
+Once logged into your new Openshift Console click on the right-hand corner where it states your login name, and then "Copy login command"
+
+You will find the token and the server url at that link.
+e.g.
+
+```
+oc login --token=XXXX --server=https://api.XXX.openshiftapps.com:6443
+```
+
+Dont forget to add the namespace you want to deploy to. in my case I use the `-dev` namespace.
+
+If you want to learn more about Quarkus, please visit its website: https://quarkus.io/ .

--- a/inventory-service/pom.xml
+++ b/inventory-service/pom.xml
@@ -59,6 +59,10 @@
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-openshift</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/price-service/pom.xml
+++ b/price-service/pom.xml
@@ -55,6 +55,10 @@
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-openshift</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/product-service/pom.xml
+++ b/product-service/pom.xml
@@ -67,6 +67,10 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-rest-client</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-openshift</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
The PR adds 
Action ci.yaml file to deploy to Openshift developer sandbox 

To deploy this project on the Sandbox, make sure you setup 3 secrets in your github repo (under settings)
- OPENSHIFT_SERVER_URL
- OPENSHIFT_NAMESPACE
- OPENSHIFT_TOKEN

Also added README section for this. The README itself is incomplete at this time. 
Fix for issue #1 